### PR TITLE
feat: k3s installation

### DIFF
--- a/deploy/compose/prod/README.md
+++ b/deploy/compose/prod/README.md
@@ -1,4 +1,4 @@
-# Deploying FBSim in production
+# Deploying FBSim in production (compose)
 
 > Steps to deploy the FBSim application in production using docker-compose
 

--- a/deploy/k8s/Chart.yaml
+++ b/deploy/k8s/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: fbsim
+description: American football simulator
+type: application
+
+# Chart version
+#
+# Increment this version on each time the chart changes
+version: v1.0.0
+
+# Application version
+#
+# Increment this version each time the underlying application changes
+appVersion: v1.0.0-alpha.1
+
+# Dependencies
+#
+# Dependencies of the FBSim deployment
+dependencies:
+  # Cert manager is used to issue TLS certificates for the FBSim API and UI
+  - name: cert-manager
+    version: "v1.16.3"
+    repository: https://charts.jetstack.io
+    condition: tls.enabled
+  # Traefik is used as the ingress backend for the FBSim API and UI
+  - name: traefik
+    version: "34.1.0"
+    repository: https://traefik.github.io/charts
+  # Ingress-nginx is used for exposing the FBSim API and UI publicly on k8s
+  - name: ingress-nginx
+    version: "4.12.0"
+    repository: https://kubernetes.github.io/ingress-nginx

--- a/deploy/k8s/Chart.yaml
+++ b/deploy/k8s/Chart.yaml
@@ -22,11 +22,3 @@ dependencies:
     version: "v1.16.3"
     repository: https://charts.jetstack.io
     condition: tls.enabled
-  # Traefik is used as the ingress backend for the FBSim API and UI
-  - name: traefik
-    version: "34.1.0"
-    repository: https://traefik.github.io/charts
-  # Ingress-nginx is used for exposing the FBSim API and UI publicly on k8s
-  - name: ingress-nginx
-    version: "4.12.0"
-    repository: https://kubernetes.github.io/ingress-nginx

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,13 @@
+# Deploying FBSim in Production (K3s)
+
+> Steps to deploy the FBSim application in production using k3s
+
+I will refine these steps tomorrow
+1. Create AWS stack
+2. Configure DNS to point at AWS stack with wildcard A record
+3. SSH into the AWS stack and install k3s
+4. Install the cert-manager CRDs
+5. Clone fbsim-deploy repo
+6. From the root of the repo, run `helm dependency build ./deploy/k8s`
+7. Ensure the helm values are customized to your needs using `vi ./deploy/k8s/values.fbsim.yaml` from the root of the repo
+8. From the root of the repo, run `helm install -f ./deploy/k8s/values.fbsim.yaml fbsim ./deploy/k8s`

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,13 +1,37 @@
-# Deploying FBSim in Production (K3s)
+# Deploying FBSim in Production (Single-node K3s)
 
-> Steps to deploy the FBSim application in production using k3s
+> Steps to deploy the FBSim application in production using single-node k3s
 
-I will refine these steps tomorrow
-1. Create AWS stack
-2. Configure DNS to point at AWS stack with wildcard A record
-3. SSH into the AWS stack and install k3s
-4. Install the cert-manager CRDs
-5. Clone fbsim-deploy repo
-6. From the root of the repo, run `helm dependency build ./deploy/k8s`
-7. Ensure the helm values are customized to your needs using `vi ./deploy/k8s/values.fbsim.yaml` from the root of the repo
-8. From the root of the repo, run `helm install -f ./deploy/k8s/values.fbsim.yaml fbsim ./deploy/k8s`
+## Step 1: Cluster setup
+
+If no machine is currently available, provision a new machine for hosting.  Ensure inbound firewall rules are configured such that ports 80 and 443 can serve public HTTP and HTTPS traffic respectively, and such that SSH traffic over port 22 is only served to your current IP.
+
+> Note: K3s does not run well on AWS t2 micro.  After moving up to t2 medium k3s ran without any apparent performance issue.
+
+After provisioning the machine,
+1. Save the private key in `~/.ssh` and `chmod 0400` the private key file for SSH into the node
+2. Map the desired domain to the newly provisioned machine, ensure propagation via [DNS checker](https://dnschecker.org/) or equivalent tooling
+   - It is recommended to 
+3. SSH into the node (if ubuntu SSH in as `ubuntu@<ip>` and then `sudo su` to operate as root user) and [install k3s](https://docs.k3s.io/quick-start)
+   - Verify the cluster is up and running by executing a `kubectl get nodes`
+    ```
+    # kubectl get nodes
+    NAME      STATUS   ROLES                       AGE   VERSION
+    fbsim-1   Ready    control-plane,etcd,master   62m   v1.31.4+k3s1
+    ```
+4. [Ensuse `git` is installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) on the machine, clone this repository onto the machine, and `cd` into the root of the repository
+5. Ensure `helm` is installed on the machine (if ubuntu run `snap install helm --classic`)
+6. Run `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml` so that `helm` can mount the kubernetes context
+
+## Step 2: Installation
+
+Once the single-node cluster is set up with all dependencies installed on the machine, the installation is as simple as the following steps, assuming you are in the root of the cloned `fbsim-deploy repository:
+1. Install the cert-manager CRDs on the cluster by running:
+   ```sh
+   export CERT_MANAGER_VERSION="v1.16.3" # Or replace with latest
+   kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml
+   ```
+2. Run `helm dependency build ./deploy/k8s`
+3. Ensure helm values file is properly customized by running `vi ./deploy/k8s/values.fbsim.yaml` and updating any values for your use case
+4. Run `helm install -f ./deploy/k8s/values.fbsim.yaml fbsim ./deploy/k8s`
+5. Wait for the certificate signing requests to complete

--- a/deploy/k8s/templates/fbsim.yaml
+++ b/deploy/k8s/templates/fbsim.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .Values.metadata.name }}-fbsim"
+  namespace: "{{ .Values.metadata.namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/component: fullstack
+    app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim"
+        app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+        app.kubernetes.io/component: fullstack
+        app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: fbsim-ui
+          image: "{{ .Values.spec.ui.registry }}/fbsim-ui:{{ .Chart.AppVersion }}"
+          env:
+            - name: FBSIM_UI_DOMAIN
+              value: "0.0.0.0"
+            - name: FBSIM_UI_PORT
+              value: "{{ .Values.spec.ui.port }}"
+            - name: FBSIM_API_HOST
+              value: "https://{{ .Values.spec.api.subdomain }}.{{ .Values.spec.domain }}"
+          ports:
+            - containerPort: {{ .Values.spec.ui.port }}
+              name: fbsim-ui
+        - name: fbsim-api
+          image: "{{ .Values.spec.api.registry }}/fbsim-api:{{ .Chart.AppVersion }}"
+          ports:
+            - containerPort: {{ .Values.spec.api.port }}
+              name: fbsim-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Values.metadata.name }}-fbsim"
+  namespace: "{{ .Values.metadata.namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/component: fullstack
+    app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim"
+  ports:
+    - name: fbsim-ui
+      protocol: TCP
+      port: {{ .Values.spec.ui.port }}
+      targetPort: {{ .Values.spec.ui.port }}
+    - name: fbsim-api
+      protocol: TCP
+      port: {{ .Values.spec.api.port }}
+      targetPort: {{ .Values.spec.api.port }}

--- a/deploy/k8s/templates/issuer.yaml
+++ b/deploy/k8s/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.tls.enabled }}
+{{ if .Values.spec.tls.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   acme:
-    email: "{{ .Values.tls.email }}"
+    email: "{{ .Values.spec.tls.email }}"
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: "{{ .Values.metadata.name }}-letsencrypt-prod"

--- a/deploy/k8s/templates/issuer.yaml
+++ b/deploy/k8s/templates/issuer.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.tls.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: "{{ .Values.metadata.name }}-letsencrypt-prod"
+  namespace: "{{ .Values.metadata.namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/component: certificate-issuer
+    app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  acme:
+    email: "{{ .Values.tls.email }}"
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    solvers:
+    - http01:
+        ingress:
+          class: traefik
+{{ end }}

--- a/deploy/k8s/templates/middleware.yaml
+++ b/deploy/k8s/templates/middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: "{{ .Values.metadata.name }}-redirect-https"
+  namespace: "{{ .Values.metadata.namespace }}"
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/deploy/k8s/templates/namespace.yaml
+++ b/deploy/k8s/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ .Values.metadata.namespace }}"
+  labels:
+    name: "{{ .Values.metadata.namespace }}"

--- a/deploy/k8s/templates/tls-ingress.yaml
+++ b/deploy/k8s/templates/tls-ingress.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Values.metadata.name }}-fbsim-api-tls-ingress"
+  namespace: "{{ .Values.metadata.namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim-api-tls-ingress"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/component: public-api-endpoint
+    app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    spec.ingressClassName: traefik
+    cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+spec:
+  rules:
+    - host: "{{ .Values.api.subdomain }}.{{ .Values.domain }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "{{ .Values.metadata.name }}-fbsim"
+                port:
+                  number: {{ .Values.api.port }}
+  tls:
+    - secretName: "{{ .Values.metadata.name }}-fbsim-api-tls"
+      hosts:
+        - "{{ .Values.api.subdomain }}.{{ .Values.domain }}"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Values.metadata.name }}-fbsim-ui-tls-ingress"
+  namespace: "{{ .Values.metadata.namespace }}"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.metadata.name }}-fbsim-ui-tls-ingress"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/component: public-ui-endpoint
+    app.kubernetes.io/part-of: "{{ .Values.metadata.name }}-fbsim"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    spec.ingressClassName: traefik
+    cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+spec:
+  rules:
+    - host: "{{ .Values.ui.subdomain }}.{{ .Values.domain }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "{{ .Values.metadata.name }}-fbsim"
+                port:
+                  number: {{ .Values.ui.port }}
+  tls:
+    - secretName: "{{ .Values.metadata.name }}-fbsim-ui-tls"
+      hosts:
+        - "{{ .Values.ui.subdomain }}.{{ .Values.domain }}"

--- a/deploy/k8s/templates/tls-ingress.yaml
+++ b/deploy/k8s/templates/tls-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     spec.ingressClassName: traefik
-    cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    cert-manager.io/issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
     traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.metadata.namespace }}-{{ .Values.metadata.name }}-redirect-https@kubernetescrd"
 spec:
   rules:
@@ -43,7 +43,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
   annotations:
     spec.ingressClassName: traefik
-    cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
+    cert-manager.io/issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
     traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.metadata.namespace }}-{{ .Values.metadata.name }}-redirect-https@kubernetescrd"
 spec:
   rules:

--- a/deploy/k8s/templates/tls-ingress.yaml
+++ b/deploy/k8s/templates/tls-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.metadata.namespace }}-{{ .Values.metadata.name }}-redirect-https@kubernetescrd"
 spec:
   rules:
     - host: "{{ .Values.spec.api.subdomain }}.{{ .Values.spec.domain }}"
@@ -44,7 +44,7 @@ metadata:
   annotations:
     spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: "{{ .Values.metadata.name }}-letsencrypt-prod"
-    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: "{{ .Values.metadata.namespace }}-{{ .Values.metadata.name }}-redirect-https@kubernetescrd"
 spec:
   rules:
     - host: "{{ .Values.spec.ui.subdomain }}.{{ .Values.spec.domain }}"

--- a/deploy/k8s/templates/tls-ingress.yaml
+++ b/deploy/k8s/templates/tls-ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
 spec:
   rules:
-    - host: "{{ .Values.api.subdomain }}.{{ .Values.domain }}"
+    - host: "{{ .Values.spec.api.subdomain }}.{{ .Values.spec.domain }}"
       http:
         paths:
           - path: /
@@ -24,11 +24,11 @@ spec:
               service:
                 name: "{{ .Values.metadata.name }}-fbsim"
                 port:
-                  number: {{ .Values.api.port }}
+                  number: {{ .Values.spec.api.port }}
   tls:
     - secretName: "{{ .Values.metadata.name }}-fbsim-api-tls"
       hosts:
-        - "{{ .Values.api.subdomain }}.{{ .Values.domain }}"
+        - "{{ .Values.spec.api.subdomain }}.{{ .Values.spec.domain }}"
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -47,7 +47,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
 spec:
   rules:
-    - host: "{{ .Values.ui.subdomain }}.{{ .Values.domain }}"
+    - host: "{{ .Values.spec.ui.subdomain }}.{{ .Values.spec.domain }}"
       http:
         paths:
           - path: /
@@ -56,8 +56,8 @@ spec:
               service:
                 name: "{{ .Values.metadata.name }}-fbsim"
                 port:
-                  number: {{ .Values.ui.port }}
+                  number: {{ .Values.spec.ui.port }}
   tls:
     - secretName: "{{ .Values.metadata.name }}-fbsim-ui-tls"
       hosts:
-        - "{{ .Values.ui.subdomain }}.{{ .Values.domain }}"
+        - "{{ .Values.spec.ui.subdomain }}.{{ .Values.spec.domain }}"

--- a/deploy/k8s/values.fbsim.yaml
+++ b/deploy/k8s/values.fbsim.yaml
@@ -1,0 +1,57 @@
+metadata:
+  # Instance name
+  #
+  # The name assigned to this instance
+  # If multiple instances, this must be unique
+  name: fbsim
+
+  # Namespace
+  #
+  # The namespace in which this instance is deployed
+  # The namespace will be created by the chart (see templates/namespace.yaml)
+  namespace: fbsim
+spec:
+  # Domain
+  #
+  # The domain behind which the application will be exposed
+  domain: whatsacomputertho.com
+
+  tls:
+    # TLS enabled
+    #
+    # Whether to enable TLS certification
+    # This installs cert-manager
+    enabled: true
+
+    # TLS config
+    #
+    # The email associated with the issued certificates
+    email: your@email.com
+
+  ui:
+    # UI image registry
+    #
+    # The registry from which to pull the fbsim-ui image
+    # The tag is derived from the chart's AppVersion
+    registry: ghcr.io/whatsacomputertho
+
+    # UI server config
+    #
+    # The subdomain behind which to expose the FBSim UI
+    # The internal port number behind which to expose the FBSim UI
+    subdomain: fbsim
+    port: 8081
+
+  api:
+    # API image registry
+    #
+    # The registry from which to pull the fbsim-ui image
+    # The tag is derived from the chart's AppVersion
+    registry: ghcr.io/whatsacomputertho
+
+    # API server config
+    #
+    # The subdomain behind which to expose the FBSim UI
+    # The internal port number behind which to expose the FBSim UI
+    subdomain: api.fbsim
+    port: 8080


### PR DESCRIPTION
In this PR, I introduce a helm chart which can be deployed on a K3s cluster and expose a production instance of FBSim.  It assumes Traefik and Ingress-Nginx both exist on the cluster.  It treats cert-manager as a dependency.