### PR TITLE
feat: parameterize domain in prod compose deploy, uplift fbsim version

### DIFF
--- a/build/acme-responder/Containerfile
+++ b/build/acme-responder/Containerfile
@@ -1,4 +1,5 @@
 FROM nginx:latest
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /opt/fbsim/template.nginx.conf
+RUN cat /opt/fbsim/template.nginx.conf | envsubst '${FBSIM_DOMAIN}' > /etc/nginx/nginx.conf
 EXPOSE 443 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/build/acme-responder/nginx.conf
+++ b/build/acme-responder/nginx.conf
@@ -5,7 +5,7 @@ events {
 http {
     server {
         listen 80;
-        server_name whatsacomputertho.com;
+        server_name $FBSIM_DOMAIN;
         resolver 127.0.0.11;
 
         location /.well-known/acme-challenge/ {

--- a/build/acme-responder/version.json
+++ b/build/acme-responder/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "1.0.0-alpha.1"
+    "version": "1.0.0-alpha.2"
 }

--- a/build/proxy/Containerfile
+++ b/build/proxy/Containerfile
@@ -1,4 +1,5 @@
 FROM nginx:latest
-COPY nginx.conf /etc/nginx/nginx.conf
+COPY nginx.conf /opt/fbsim/template.nginx.conf
+RUN cat /opt/fbsim/template.nginx.conf | envsubst '${FBSIM_DOMAIN}' > /etc/nginx/nginx.conf
 EXPOSE 443 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/build/proxy/nginx.conf
+++ b/build/proxy/nginx.conf
@@ -5,11 +5,11 @@ events {
 http {
     server {
         listen 443 ssl;
-        ssl_certificate /etc/letsencrypt/live/whatsacomputertho.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/whatsacomputertho.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/$FBSIM_DOMAIN/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/$FBSIM_DOMAIN/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-        server_name whatsacomputertho.com;
+        server_name $FBSIM_DOMAIN;
         resolver 127.0.0.11;
 
         location /.well-known/acme-challenge/ {
@@ -44,7 +44,7 @@ http {
 
     server {
         listen 80;
-        server_name whatsacomputertho.com;
+        server_name $FBSIM_DOMAIN;
         return 302 https://$server_name$request_uri;
     }
 }

--- a/build/proxy/version.json
+++ b/build/proxy/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "1.0.0-alpha.1"
+    "version": "1.0.0-alpha.2"
 }

--- a/deploy/compose/local/docker-compose.yaml
+++ b/deploy/compose/local/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.2}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.3}
     ports:
       - "8080:8080"
   ui:
-    image: ghcr.io/whatsacomputertho/fbsim-ui:${FBSIM_UI_VERSION:-v1.0.0-alpha.1}
+    image: ghcr.io/whatsacomputertho/fbsim-ui:${FBSIM_UI_VERSION:-v1.0.0-alpha.2}
     ports:
       - "8081:8081"
     environment:

--- a/deploy/compose/prod/README.md
+++ b/deploy/compose/prod/README.md
@@ -26,7 +26,8 @@ Steps for doing so are outlined as follows:
 2. Run the `acme-responder` image in the background, which we will use as a temporary webserver to respond to the certbot challenge
     ```sh
     # Run the acme-responder container
-    docker run -d -it -p 80:80 --volume ./data/certbot/www:/var/www/certbot ghcr.io/whatsacomputertho/fbsim-acme-responder:v1.0.0-alpha.1
+    export FBSIM_DOMAIN="my.domain.com" # Set to your domain
+    docker run -d -it -p 80:80 --env FBSIM_DOMAIN="${FBSIM_DOMAIN}" --volume ./data/certbot/www:/var/www/certbot ghcr.io/whatsacomputertho/fbsim-acme-responder:v1.0.0-alpha.1
     
     # List running container images, check the logs to ensure healthy startup
     docker container ls

--- a/deploy/compose/prod/docker-compose.yaml
+++ b/deploy/compose/prod/docker-compose.yaml
@@ -4,14 +4,16 @@ services:
     ports:
       - 443:443
       - 80:80
+    environment:
+      - FBSIM_DOMAIN=${FBSIM_DOMAIN:-whatsacomputertho.com}
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.1}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.3}
     ports:
       - "8080:8080"
   ui:
-    image: ghcr.io/whatsacomputertho/fbsim-ui:${FBSIM_UI_VERSION:-v1.0.0-alpha.1}
+    image: ghcr.io/whatsacomputertho/fbsim-ui:${FBSIM_UI_VERSION:-v1.0.0-alpha.2}
     ports:
       - "8081:8081"
     environment:

--- a/deploy/k8s/Chart.yaml
+++ b/deploy/k8s/Chart.yaml
@@ -11,7 +11,7 @@ version: v1.0.0
 # Application version
 #
 # Increment this version each time the underlying application changes
-appVersion: v1.0.0-alpha.1
+appVersion: v1.0.0-alpha.2
 
 # Dependencies
 #

--- a/deploy/k8s/values.fbsim.yaml
+++ b/deploy/k8s/values.fbsim.yaml
@@ -34,7 +34,7 @@ spec:
     # The registry from which to pull the fbsim-ui image
     # The version of the image (image tag) to pull
     registry: ghcr.io/whatsacomputertho
-    version: v1.0.0-alpha.1
+    version: v1.0.0-alpha.2
 
     # UI server config
     #
@@ -49,7 +49,7 @@ spec:
     # The registry from which to pull the fbsim-ui image
     # The version of the image (image tag) to pull
     registry: ghcr.io/whatsacomputertho
-    version: v1.0.0-alpha.2
+    version: v1.0.0-alpha.3
 
     # API server config
     #


### PR DESCRIPTION
In this PR, I parameterize the domain name in the fbsim-acme-responder and fbsim-proxy NGINX config files.  I also uplift the FBSim version across each deployment to bring in the latest changes in the UI and API.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-deploy/issues/5
- https://github.com/whatsacomputertho/fbsim-api/issues/4
- https://github.com/whatsacomputertho/fbsim-ui/issues/3