### PR TITLE
chore: upgrade to fbsim-api v1.0.0-alpha.4 for tie resim feature

### DIFF
--- a/deploy/compose/local/docker-compose.yaml
+++ b/deploy/compose/local/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.3}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.4}
     ports:
       - "8080:8080"
   ui:

--- a/deploy/compose/prod/docker-compose.yaml
+++ b/deploy/compose/prod/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.3}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.4}
     ports:
       - "8080:8080"
   ui:

--- a/deploy/k8s/values.fbsim.yaml
+++ b/deploy/k8s/values.fbsim.yaml
@@ -49,7 +49,7 @@ spec:
     # The registry from which to pull the fbsim-ui image
     # The version of the image (image tag) to pull
     registry: ghcr.io/whatsacomputertho
-    version: v1.0.0-alpha.3
+    version: v1.0.0-alpha.4
 
     # API server config
     #


### PR DESCRIPTION
In this PR, I upgrade to fbsim-api v1.0.0-alpha.4, which itself upgrades to fbsim-core v1.0.0-alpha.8, which introduces the tie-resim capability.  This makes the probability of a tie in the model fit actual football data.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/15