### PR TITLE
fix: upgrade to fbsim-api v1.0.0-alpha.5

### DIFF
--- a/deploy/compose/local/docker-compose.yaml
+++ b/deploy/compose/local/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.4}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.5}
     ports:
       - "8080:8080"
   ui:

--- a/deploy/compose/prod/docker-compose.yaml
+++ b/deploy/compose/prod/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./data/certbot/conf:/etc/letsencrypt
   api:
-    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.4}
+    image: ghcr.io/whatsacomputertho/fbsim-api:${FBSIM_API_VERSION:-v1.0.0-alpha.5}
     ports:
       - "8080:8080"
   ui:

--- a/deploy/k8s/values.fbsim.yaml
+++ b/deploy/k8s/values.fbsim.yaml
@@ -49,7 +49,7 @@ spec:
     # The registry from which to pull the fbsim-ui image
     # The version of the image (image tag) to pull
     registry: ghcr.io/whatsacomputertho
-    version: v1.0.0-alpha.4
+    version: v1.0.0-alpha.5
 
     # API server config
     #


### PR DESCRIPTION
In this PR, I upgrade to fbsim-api v1.0.0-alpha.5 to bring in a fix mentioned in my previous fbsim-cli and fbsim-api PRs
- https://github.com/whatsacomputertho/fbsim-cli/pull/7
- https://github.com/whatsacomputertho/fbsim-api/pull/8

Specifically,
> I also found that there was a bug in the core model - I had the coefficient and the intercept backwards - which led to worse teams performing better overall against better opponents.